### PR TITLE
Set english as the default locale for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ lazy val testSuite: CrossProject = CrossProject(
     fork in Test := true,
     // Use CLDR provider for locales
     // https://docs.oracle.com/javase/8/docs/technotes/guides/intl/enhancements.8.html#cldr
-    javaOptions in Test += "-Djava.locale.providers=CLDR",
+    javaOptions in Test ++= Seq("-Duser.language=en", "-Duser.country=", "-Djava.locale.providers=CLDR"),
     name := "scalajs-locales testSuite on JVM",
     libraryDependencies +=
       "com.novocode" % "junit-interface" % "0.9" % "test"

--- a/testSuite/js/src/test/scala/org/scalajs/testsuite/utils/LocaleTestSetup.scala
+++ b/testSuite/js/src/test/scala/org/scalajs/testsuite/utils/LocaleTestSetup.scala
@@ -1,9 +1,13 @@
 package org.scalajs.testsuite.utils
 
+import java.util.Locale
+
 import scala.scalajs.LocaleRegistry
 
 class LocaleTestSetup {
   def cleanDatabase: Unit = {
     LocaleRegistry.resetRegistry()
+    // Reset the default locale to english
+    Locale.setDefault(Locale.ENGLISH)
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
@@ -242,21 +242,15 @@ class LocaleTest extends LocaleTestSetup {
     assertEquals(Locale.TRADITIONAL_CHINESE, Locale.TAIWAN)
   }
 
-  // Unlike the JVM, the Js backend cannot give a default locale
+  // The tests operate with ENGLISH as the default locale
   @Test def test_no_default_locale(): Unit = {
-    if (!Platform.executingInJVM) {
-      expectThrows(classOf[IllegalStateException], Locale.getDefault)
-    }
+    assertEquals(Locale.ENGLISH, Locale.getDefault)
   }
 
   // Unlike the JVM, the Js backend cannot give a default locale
   @Test def test_no_default_locale_per_category(): Unit = {
-    if (!Platform.executingInJVM) {
-      expectThrows(classOf[IllegalStateException],
-          Locale.getDefault(Locale.Category.DISPLAY))
-      expectThrows(classOf[IllegalStateException],
-          Locale.getDefault(Locale.Category.FORMAT))
-    }
+    assertEquals(Locale.ENGLISH, Locale.getDefault(Locale.Category.DISPLAY))
+    assertEquals(Locale.ENGLISH, Locale.getDefault(Locale.Category.FORMAT))
     expectThrows(classOf[NullPointerException], Locale.getDefault(null))
   }
 


### PR DESCRIPTION
This is important for constructors that rely on being a default locale